### PR TITLE
アーキテクチャリファクタリング

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     alias(libs.plugins.kotlinAndroid)
     alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.ksp)
-    id("kotlin-kapt")
     id("kotlin-parcelize")
     id("androidx.navigation.safeargs.kotlin")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,9 @@ android {
 
 kotlin {
     jvmToolchain(libs.versions.javaVersion.get().toInt())
+    sourceSets.all {
+        languageSettings.enableLanguageFeature("ExplicitBackingFields")
+    }
 }
 
 dependencies {

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/codecheck/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/codecheck/ExampleInstrumentedTest.kt
@@ -8,6 +8,7 @@ import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
+import jp.co.yumemi.android.codecheck.api.RepositorySearchResponse
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/RepositoryDetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/RepositoryDetailFragment.kt
@@ -4,24 +4,22 @@
 package jp.co.yumemi.android.codecheck
 
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import coil.load
-import jp.co.yumemi.android.codecheck.TopActivity.Companion.lastSearchDate
 import jp.co.yumemi.android.codecheck.databinding.FragmentDetailBinding
+import org.koin.android.ext.android.inject
 
 class RepositoryDetailFragment : Fragment(R.layout.fragment_detail) {
 
     private val args: RepositoryDetailFragmentArgs by navArgs()
 
     private lateinit var binding: FragmentDetailBinding
+    private val searchClient by inject<SearchClient>()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        Log.d("検索した日時", lastSearchDate.toString())
 
         binding = FragmentDetailBinding.bind(view)
 
@@ -34,5 +32,7 @@ class RepositoryDetailFragment : Fragment(R.layout.fragment_detail) {
         binding.watchersView.text = getString(R.string.count_watchers, item.watchersCount)
         binding.forksView.text = getString(R.string.count_forks, item.forksCount)
         binding.openIssuesView.text = getString(R.string.count_open_issues, item.openIssuesCount)
+        binding.searchDate.text =
+            getString(R.string.search_text, searchClient.lastSearchDate.toString())
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/RepositoryDetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/RepositoryDetailFragment.kt
@@ -8,6 +8,7 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import coil.load
+import jp.co.yumemi.android.codecheck.api.SearchClient
 import jp.co.yumemi.android.codecheck.databinding.FragmentDetailBinding
 import org.koin.android.ext.android.inject
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchClient.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchClient.kt
@@ -1,0 +1,32 @@
+package jp.co.yumemi.android.codecheck
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.statement.HttpResponse
+import kotlinx.serialization.json.Json
+import org.koin.core.annotation.Single
+import java.util.Date
+
+@Single
+class SearchClient(
+    private val client: HttpClient,
+    private val json: Json,
+) {
+    var lastSearchDate = Date()
+        private set
+
+    suspend fun searchRepository(query: String): List<RepositoryInfo> {
+        val response: HttpResponse = client.get("https://api.github.com/search/repositories") {
+            header("Accept", "application/vnd.github.v3+json")
+            parameter("q", query)
+        }
+
+        val jsonResponse = json.decodeFromString<RepositorySearchResponse>(response.body())
+        lastSearchDate = Date()
+
+        return jsonResponse.items
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchFragment.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import jp.co.yumemi.android.codecheck.adapter.CustomAdapter
 import jp.co.yumemi.android.codecheck.adapter.OnItemClickListener
+import jp.co.yumemi.android.codecheck.api.RepositoryInfo
 import jp.co.yumemi.android.codecheck.databinding.FragmentSearchBinding
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchFragment.kt
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import jp.co.yumemi.android.codecheck.adapter.CustomAdapter
 import jp.co.yumemi.android.codecheck.adapter.OnItemClickListener
 import jp.co.yumemi.android.codecheck.databinding.FragmentSearchBinding
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
@@ -41,10 +42,7 @@ class SearchFragment : Fragment(R.layout.fragment_search) {
                     if (inputText.isBlank()) {
                         editText.error = "文字を入力してください"
                     } else {
-                        lifecycleScope.launch {
-                            val result = viewModel.searchResults(inputText).await()
-                            adapter.submitList(result)
-                        }
+                        viewModel.searchResults(inputText)
                     }
                 }
                 return@setOnEditorActionListener true
@@ -54,6 +52,13 @@ class SearchFragment : Fragment(R.layout.fragment_search) {
             it.layoutManager = layoutManager
             it.addItemDecoration(dividerItemDecoration)
             it.adapter = adapter
+        }
+
+        lifecycleScope.launch {
+            viewModel.list.collectLatest {
+                // TODO: emptyやらindicatorやら表示
+                adapter.submitList(it)
+            }
         }
     }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchViewModel.kt
@@ -14,6 +14,7 @@ import io.ktor.client.statement.HttpResponse
 import jp.co.yumemi.android.codecheck.TopActivity.Companion.lastSearchDate
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.json.Json
 import org.koin.android.annotation.KoinViewModel
 import java.util.Date
@@ -23,6 +24,8 @@ class SearchViewModel(
     private val client: HttpClient,
     private val json: Json,
 ) : ViewModel() {
+    val list: StateFlow<List<RepositoryInfo>>
+        field = kotlinx.coroutines.flow.MutableStateFlow<List<RepositoryInfo>>(kotlin.collections.listOf())
 
     // 検索結果
     suspend fun searchResults(inputText: String): Deferred<List<RepositoryInfo>> =

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchViewModel.kt
@@ -5,6 +5,8 @@ package jp.co.yumemi.android.codecheck
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import jp.co.yumemi.android.codecheck.api.RepositoryInfo
+import jp.co.yumemi.android.codecheck.api.SearchClient
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.StateFlow
 import org.koin.android.annotation.KoinViewModel

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchViewModel.kt
@@ -12,9 +12,8 @@ import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.statement.HttpResponse
 import jp.co.yumemi.android.codecheck.TopActivity.Companion.lastSearchDate
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import org.koin.android.annotation.KoinViewModel
 import java.util.Date
@@ -28,8 +27,8 @@ class SearchViewModel(
         field = kotlinx.coroutines.flow.MutableStateFlow<List<RepositoryInfo>>(kotlin.collections.listOf())
 
     // 検索結果
-    suspend fun searchResults(inputText: String): Deferred<List<RepositoryInfo>> =
-        viewModelScope.async {
+    fun searchResults(inputText: String) {
+        viewModelScope.launch {
             val response: HttpResponse = client.get("https://api.github.com/search/repositories") {
                 header("Accept", "application/vnd.github.v3+json")
                 parameter("q", inputText)
@@ -38,6 +37,7 @@ class SearchViewModel(
             val jsonResponse = json.decodeFromString<RepositorySearchResponse>(response.body())
             lastSearchDate = Date()
 
-            return@async jsonResponse.items
+            list.value = jsonResponse.items
         }
+    }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchViewModel.kt
@@ -5,39 +5,21 @@ package jp.co.yumemi.android.codecheck
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.get
-import io.ktor.client.request.header
-import io.ktor.client.request.parameter
-import io.ktor.client.statement.HttpResponse
-import jp.co.yumemi.android.codecheck.TopActivity.Companion.lastSearchDate
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
-import kotlinx.serialization.json.Json
 import org.koin.android.annotation.KoinViewModel
-import java.util.Date
 
 @KoinViewModel
 class SearchViewModel(
-    private val client: HttpClient,
-    private val json: Json,
+    private val searchClient: SearchClient,
 ) : ViewModel() {
     val list: StateFlow<List<RepositoryInfo>>
         field = kotlinx.coroutines.flow.MutableStateFlow<List<RepositoryInfo>>(kotlin.collections.listOf())
 
     // 検索結果
     fun searchResults(inputText: String) {
-        viewModelScope.launch {
-            val response: HttpResponse = client.get("https://api.github.com/search/repositories") {
-                header("Accept", "application/vnd.github.v3+json")
-                parameter("q", inputText)
-            }
-
-            val jsonResponse = json.decodeFromString<RepositorySearchResponse>(response.body())
-            lastSearchDate = Date()
-
-            list.value = jsonResponse.items
+        viewModelScope.async {
+            list.value = searchClient.searchRepository(inputText)
         }
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/TopActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/TopActivity.kt
@@ -4,11 +4,6 @@
 package jp.co.yumemi.android.codecheck
 
 import androidx.appcompat.app.AppCompatActivity
-import java.util.Date
 
 class TopActivity : AppCompatActivity(R.layout.activity_top) {
-
-    companion object {
-        lateinit var lastSearchDate: Date
-    }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/adapter/CustomAdapter.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/adapter/CustomAdapter.kt
@@ -5,7 +5,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import jp.co.yumemi.android.codecheck.R
-import jp.co.yumemi.android.codecheck.RepositoryInfo
+import jp.co.yumemi.android.codecheck.api.RepositoryInfo
 
 class CustomAdapter(
     private val itemClickListener: OnItemClickListener,

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/adapter/OnItemClickListener.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/adapter/OnItemClickListener.kt
@@ -1,6 +1,6 @@
 package jp.co.yumemi.android.codecheck.adapter
 
-import jp.co.yumemi.android.codecheck.RepositoryInfo
+import jp.co.yumemi.android.codecheck.api.RepositoryInfo
 
 interface OnItemClickListener {
     fun itemClick(item: RepositoryInfo)

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/adapter/ViewHolder.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/adapter/ViewHolder.kt
@@ -4,7 +4,7 @@ import android.view.View
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import jp.co.yumemi.android.codecheck.R
-import jp.co.yumemi.android.codecheck.RepositoryInfo
+import jp.co.yumemi.android.codecheck.api.RepositoryInfo
 
 class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
     private val nameText = view.findViewById<TextView>(R.id.repositoryNameView)

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/api/RepositoryInfo.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/api/RepositoryInfo.kt
@@ -1,4 +1,4 @@
-package jp.co.yumemi.android.codecheck
+package jp.co.yumemi.android.codecheck.api
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/api/SearchClient.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/api/SearchClient.kt
@@ -1,4 +1,4 @@
-package jp.co.yumemi.android.codecheck
+package jp.co.yumemi.android.codecheck.api
 
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body

--- a/app/src/main/res/layout/fragment_detail.xml
+++ b/app/src/main/res/layout/fragment_detail.xml
@@ -109,4 +109,15 @@
             tools:text="131 open issues"
             />
 
+    <TextView
+            android:id="@+id/search_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:text="検索日：1月1日"
+            />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -27,7 +27,7 @@
             >
         <argument
                 android:name="item"
-                app:argType="jp.co.yumemi.android.codecheck.RepositoryInfo"
+                app:argType="jp.co.yumemi.android.codecheck.api.RepositoryInfo"
                 />
     </fragment>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
     <string name="count_watchers">%d watchers</string>
     <string name="count_forks">%d forks</string>
     <string name="count_open_issues">%d open issues</string>
+    <string name="search_text">検索日：%1$s</string>
 </resources>

--- a/app/src/test/kotlin/jp/co/yumemi/android/codecheck/ExampleUnitTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/codecheck/ExampleUnitTest.kt
@@ -1,67 +1,16 @@
 package jp.co.yumemi.android.codecheck
 
 import io.kotest.matchers.shouldBe
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.get
-import io.ktor.client.request.header
-import io.ktor.client.request.parameter
-import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.bodyAsText
-import jp.co.yumemi.android.codecheck.api.RepositorySearchResponse
-import jp.co.yumemi.android.codecheck.di.networkModule
-import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.json.Json
-import org.junit.After
-import org.junit.Before
 import org.junit.Test
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
-import org.koin.test.KoinTest
-import org.koin.test.inject
 
 /**
  * Example local unit test, which will execute on the development machine (host).
  *
  * See [testing documentation](http://d.android.com/tools/testing).
  */
-class ExampleUnitTest : KoinTest {
-    private val client by inject<HttpClient>()
-    private val json by inject<Json>()
-
-    @Before
-    fun setup() {
-        startKoin {
-            modules(networkModule)
-        }
-    }
-
-    @After
-    fun tearDown() {
-        stopKoin()
-    }
-
+class ExampleUnitTest {
     @Test
-    fun `response total count = 11`(): Unit = runBlocking {
-        val response: HttpResponse = client.get("https://api.github.com/search/repositories") {
-            header("Accept", "application/vnd.github.v3+json")
-            parameter("q", "asdfghjkk")
-        }
-
-        val jsonBody = json.decodeFromString<RepositorySearchResponse>(response.body())
-        jsonBody.items.size shouldBe 11
-    }
-
-    @Test
-    fun `response total count = 0`(): Unit = runBlocking {
-        val response: HttpResponse = client.get("https://api.github.com/search/repositories") {
-            header("Accept", "application/vnd.github.v3+json")
-            parameter("q", "asdfghjkkkjlkjlkjiouore")
-        }
-
-        val str = response.bodyAsText()
-        println(str)
-        val jsonBody = json.decodeFromString<RepositorySearchResponse>(str)
-        jsonBody.items.size shouldBe 0
+    fun test() {
+        1 + 2 shouldBe 3
     }
 }

--- a/app/src/test/kotlin/jp/co/yumemi/android/codecheck/ExampleUnitTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/codecheck/ExampleUnitTest.kt
@@ -8,6 +8,7 @@ import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
+import jp.co.yumemi.android.codecheck.api.RepositorySearchResponse
 import jp.co.yumemi.android.codecheck.di.networkModule
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json

--- a/app/src/test/kotlin/jp/co/yumemi/android/codecheck/api/RepositoryInfoTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/codecheck/api/RepositoryInfoTest.kt
@@ -1,4 +1,4 @@
-package jp.co.yumemi.android.codecheck
+package jp.co.yumemi.android.codecheck.api
 
 import io.kotest.matchers.shouldBe
 import jp.co.yumemi.android.codecheck.di.networkModule

--- a/app/src/test/kotlin/jp/co/yumemi/android/codecheck/api/SearchClientTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/codecheck/api/SearchClientTest.kt
@@ -1,0 +1,46 @@
+package jp.co.yumemi.android.codecheck.api
+
+import io.kotest.matchers.shouldBe
+import jp.co.yumemi.android.codecheck.di.ScanModule
+import jp.co.yumemi.android.codecheck.di.networkModule
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.ksp.generated.module
+import org.koin.test.KoinTest
+import org.koin.test.inject
+
+class SearchClientTest : KoinTest {
+    private val client by inject<SearchClient>()
+
+    @Before
+    fun setup() {
+        startKoin {
+            modules(
+                ScanModule().module,
+                networkModule,
+            )
+        }
+    }
+
+    @After
+    fun tearDown() {
+        stopKoin()
+    }
+
+
+    @Test
+    fun `response total count = 11`(): Unit = runBlocking {
+        val actual = client.searchRepository("asdfghjkk")
+        actual.size shouldBe 11
+    }
+
+    @Test
+    fun `response total count = 0`(): Unit = runBlocking {
+        val actual = client.searchRepository("asdfghjkkkjlkjlkjiouore")
+        actual.size shouldBe 0
+    }
+}


### PR DESCRIPTION
- 検索結果をViewModelで保持するよう変更
- 検索処理を専用クラスに書き出し（usecaseみたいな感じになったような気がする）
- 検索日時の保持をActivityで共有する形からSearchClientに移行
- パッケージ構成のリファクタリング（単なる移動）
- ExplicitBackingFieldsを有効化して使ってみた

これで一通りの修正が終わったため、以下のissueはclose

close #5 
close #6 
close #7 

またMVVMのアーキテクチャに変更したことに伴い、検索結果の保持が効くようになったため、以下のissueもクローズする。
close #14 