### PR TITLE
kotlinx-datetimeを導入

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,6 +85,7 @@ kotlin {
 }
 
 dependencies {
+    implementation(project(":kmpShare"))
     implementation(libs.androidxCoreKtx)
 
     implementation(libs.androidxActivityCompose)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,7 +29,7 @@ android {
             isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
         }
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,7 @@ android {
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.toVersion(libs.versions.javaVersion.get().toInt())
         targetCompatibility = JavaVersion.toVersion(libs.versions.javaVersion.get().toInt())
     }
@@ -85,6 +86,8 @@ kotlin {
 }
 
 dependencies {
+    coreLibraryDesugaring(libs.desugar)
+
     implementation(project(":kmpShare"))
     implementation(libs.androidxCoreKtx)
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/RepositoryDetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/RepositoryDetailFragment.kt
@@ -14,6 +14,12 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import jp.co.yumemi.android.codecheck.api.SearchClient
 import jp.co.yumemi.android.codecheck.ui.RepositoryDetailContent
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.format
+import kotlinx.datetime.format.Padding
+import kotlinx.datetime.format.char
+import kotlinx.datetime.toLocalDateTime
 import org.koin.android.ext.android.inject
 
 class RepositoryDetailFragment : Fragment() {
@@ -32,7 +38,24 @@ class RepositoryDetailFragment : Fragment() {
                 MaterialTheme {
                     RepositoryDetailContent(
                         info = args.item,
-                        lastSearchDate = searchClient.lastSearchDate.toString(),
+                        lastSearchDate = searchClient
+                            .lastSearchDate
+                            .toLocalDateTime(TimeZone.currentSystemDefault())
+                            .format(
+                                LocalDateTime.Format {
+                                    year()
+                                    char('年')
+                                    monthNumber(Padding.SPACE)
+                                    char('月')
+                                    dayOfMonth(Padding.SPACE)
+                                    chars("日 ")
+                                    hour()
+                                    char(':')
+                                    minute()
+                                    char(':')
+                                    second()
+                                },
+                            ),
                     )
                 }
             }

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/api/SearchClient.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/api/SearchClient.kt
@@ -6,7 +6,8 @@ import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.statement.HttpResponse
-import java.util.Date
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlinx.serialization.json.Json
 import org.koin.core.annotation.Single
 
@@ -15,7 +16,7 @@ class SearchClient(
     private val client: HttpClient,
     private val json: Json,
 ) {
-    var lastSearchDate = Date()
+    var lastSearchDate: Instant = Clock.System.now()
         private set
 
     suspend fun searchRepository(query: String): List<RepositoryInfo> {
@@ -25,7 +26,7 @@ class SearchClient(
         }
 
         val jsonResponse = json.decodeFromString<RepositorySearchResponse>(response.body())
-        lastSearchDate = Date()
+        lastSearchDate = Clock.System.now()
 
         return jsonResponse.items
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ koinAnnotation = "1.3.1"
 
 [libraries]
 coilCompose = { module = "io.coil-kt:coil-compose", version = "2.6.0" }
+desugar = { module = "com.android.tools:desugar_jdk_libs", version = "2.0.4" }
 androidxCoreKtx = { module = "androidx.core:core-ktx", version = "1.6.0" }
 androidxTestEspressoCore = { module = "androidx.test.espresso:espresso-core", version = "3.4.0" }
 androidxTextJunit = { module = "androidx.test.ext:junit", version = "1.1.5" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ androidxNavigationUiKtx = { module = "androidx.navigation:navigation-ui-ktx", ve
 kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotestAssertion = { module = "io.kotest:kotest-assertions-core", version = "5.9.0" }
 kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.7.0-RC" }
+kotlinxDatetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.6.0" }
 koinCore = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koinTest = { module = "io.insert-koin:koin-test", version.ref = "koin" }
 koinAndroid = { module = "io.insert-koin:koin-android", version.ref = "koin" }

--- a/kmpShare/build.gradle.kts
+++ b/kmpShare/build.gradle.kts
@@ -52,7 +52,8 @@ kotlin {
             implementation(compose.foundation)
             implementation(compose.components.resources)
 
-            implementation(libs.kotlinxDatetime)
+            // TODO: appモジュールで参照するため一時的にapiにする
+            api(libs.kotlinxDatetime)
         }
         commonTest.dependencies {
             implementation(libs.kotlinTest)

--- a/kmpShare/build.gradle.kts
+++ b/kmpShare/build.gradle.kts
@@ -60,7 +60,6 @@ kotlin {
             implementation(libs.kotestAssertion)
         }
         wasmJsMain.dependencies {
-            implementation(npm("@js-joda/timezone", "2.3.0"))
         }
     }
 }

--- a/kmpShare/build.gradle.kts
+++ b/kmpShare/build.gradle.kts
@@ -46,18 +46,20 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            //put your multiplatform dependencies here
             implementation(compose.runtime)
             implementation(compose.ui)
             implementation(compose.material3)
             implementation(compose.foundation)
             implementation(compose.components.resources)
+
+            implementation(libs.kotlinxDatetime)
         }
         commonTest.dependencies {
             implementation(libs.kotlinTest)
             implementation(libs.kotestAssertion)
         }
         wasmJsMain.dependencies {
+            implementation(npm("@js-joda/timezone", "2.3.0"))
         }
     }
 }


### PR DESCRIPTION
FullComposeの作業の一環 #71 
java.util.Date()を使っている箇所があるので、これをkotlinx-datetimeで置き換えた

https://github.com/Kotlin/kotlinx-datetime/

普段使ったことのあるjava.timeと似ているようで結構違う
というかjava.timeのように使うと痛い目をみる（`LocalDateTime.now()`とかしちゃう）

kotlinx-datetimeは時間軸上のある一点をInstant、そのInstantをどう解釈するか（そのある一点を何月何日の何時何分とするか）をLocalDateTimeで表現する
基本はInstantで時点を持って、表示したりするのにLocalDateTimeに変換するイメージで使うと良い気がした
