### PR TITLE
Koinで依存性解決させるように変更

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,6 +77,8 @@ dependencies {
     implementation(libs.androidxCoreKtx)
     implementation(libs.googleMaterial)
 
+    implementation(libs.koinAndroid)
+
     implementation(libs.androidxActivityCompose)
     implementation(libs.androidxFragmentCompose)
     implementation(libs.androidxComposeMaterial)

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/CodeCheckApp.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/CodeCheckApp.kt
@@ -1,5 +1,17 @@
 package jp.co.yumemi.android.codecheck
 
 import android.app.Application
+import jp.co.yumemi.codecheck.koin
+import org.koin.android.ext.koin.androidContext
+import org.koin.android.ext.koin.androidLogger
 
-class CodeCheckApp : Application()
+class CodeCheckApp : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        koin.apply {
+            androidLogger()
+            androidContext(this@CodeCheckApp)
+        }
+    }
+}

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/App.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/App.kt
@@ -3,7 +3,17 @@ package jp.co.yumemi.codecheck
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import cafe.adriel.voyager.navigator.Navigator
+import jp.co.yumemi.codecheck.di.networkModule
+import jp.co.yumemi.codecheck.di.screenModelModule
 import jp.co.yumemi.codecheck.ui.search.SearchScreen
+import org.koin.core.context.startKoin
+
+val koin = startKoin {
+    modules(
+        networkModule,
+        screenModelModule,
+    )
+}
 
 @Composable
 fun App() {

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/di/ScreenModelModule.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/di/ScreenModelModule.kt
@@ -1,0 +1,11 @@
+package jp.co.yumemi.codecheck.di
+
+import jp.co.yumemi.codecheck.ui.detail.RepositoryDetailScreenModel
+import jp.co.yumemi.codecheck.ui.search.SearchScreenModel
+import org.koin.core.module.dsl.factoryOf
+import org.koin.dsl.module
+
+val screenModelModule = module {
+    factoryOf(::SearchScreenModel)
+    factoryOf(::RepositoryDetailScreenModel)
+}

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/detail/RepositoryDetailScreen.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/detail/RepositoryDetailScreen.kt
@@ -4,26 +4,16 @@ import androidx.compose.runtime.Composable
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.core.screen.Screen
 import jp.co.yumemi.codecheck.api.RepositoryInfo
-import jp.co.yumemi.codecheck.api.SearchClient
-import jp.co.yumemi.codecheck.httpClient
-import kotlinx.serialization.json.Json
+import org.koin.core.component.KoinComponent
 
 data class RepositoryDetailScreen(
     private val info: RepositoryInfo,
-) : Screen {
+) : Screen, KoinComponent {
     @Composable
     override fun Content() {
         val screenModel: RepositoryDetailScreenModel =
             rememberScreenModel<RepositoryDetailScreenModel> {
-                // TODO: 一時的にこうしてるだけ
-                RepositoryDetailScreenModel(
-                    SearchClient(
-                        client = httpClient(),
-                        json = Json {
-                            ignoreUnknownKeys = true
-                        },
-                    ),
-                )
+                getKoin().get<RepositoryDetailScreenModel>()
             }
 
         RepositoryDetailContent(

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/detail/RepositoryDetailScreen.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/detail/RepositoryDetailScreen.kt
@@ -5,6 +5,7 @@ import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.core.screen.Screen
 import jp.co.yumemi.codecheck.api.RepositoryInfo
 import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
 data class RepositoryDetailScreen(
     private val info: RepositoryInfo,
@@ -13,7 +14,7 @@ data class RepositoryDetailScreen(
     override fun Content() {
         val screenModel: RepositoryDetailScreenModel =
             rememberScreenModel<RepositoryDetailScreenModel> {
-                getKoin().get<RepositoryDetailScreenModel>()
+                inject<RepositoryDetailScreenModel>().value
             }
 
         RepositoryDetailContent(

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreen.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreen.kt
@@ -9,13 +9,14 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import jp.co.yumemi.codecheck.ui.detail.RepositoryDetailScreen
 import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
 class SearchScreen : Screen, KoinComponent {
     @Composable
     override fun Content() {
         val navigator = LocalNavigator.currentOrThrow
         val screenModel = rememberScreenModel<SearchScreenModel> {
-            getKoin().get<SearchScreenModel>()
+            inject<SearchScreenModel>().value
         }
         val state by screenModel.state.collectAsState()
 

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreen.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreen.kt
@@ -7,23 +7,15 @@ import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
-import jp.co.yumemi.codecheck.api.SearchClient
-import jp.co.yumemi.codecheck.httpClient
 import jp.co.yumemi.codecheck.ui.detail.RepositoryDetailScreen
-import kotlinx.serialization.json.Json
+import org.koin.core.component.KoinComponent
 
-class SearchScreen : Screen {
+class SearchScreen : Screen, KoinComponent {
     @Composable
     override fun Content() {
         val navigator = LocalNavigator.currentOrThrow
         val screenModel = rememberScreenModel<SearchScreenModel> {
-            // TODO: 一時的にこうしてるだけ
-            SearchScreenModel(
-                SearchClient(
-                    httpClient(),
-                    Json { ignoreUnknownKeys = true },
-                ),
-            )
+            getKoin().get<SearchScreenModel>()
         }
         val state by screenModel.state.collectAsState()
 


### PR DESCRIPTION
KoinComponentを導入すればできた
koinの初期化もkmpShareモジュールで行った

android特有のモジュールなど後から追加することも可能（に見える）