### PR TITLE
Webで検索が効かない問題を修正

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+org.jetbrains.compose.experimental.jscanvas.enabled=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.0.0"
 ksp = "2.0.0-1.0.22"
 javaVersion = "17"
 
-coroutine = "1.9.0-RC"
+coroutine = "1.8.1"
 ktor = "3.0.0-wasm2"
 lifecycle = "2.5.1"
 koin = "3.6.0-wasm-alpha2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,8 @@ ktorCoreJs = { module = "io.ktor:ktor-client-core-wasm-js", version.ref = "ktor"
 ktorClientJsWasmJs = { module = "io.ktor:ktor-client-js-wasm-js", version.ref = "ktor" }
 ktorClientAndroid = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
 ktorClientLogging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
+ktorClientContentNegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktorClientSerialization = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 
 androidxLifecycleLivedataKtx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycle" }
 androidxLifecycleRuntimeKtx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,8 @@ ktorCio = { module = "io.ktor:ktor-client-cio", version = "3.0.0-wasm2" }
 ktorCoreJs = { module = "io.ktor:ktor-client-core-wasm-js", version.ref = "ktor" }
 ktorClientJsWasmJs = "io.ktor:ktor-client-js-wasm-js:3.2.0"
 ktorClientAndroid = "io.ktor:ktor-client-android:3.0.0-wasm2"
+ktorClientLogging = "io.ktor:ktor-client-logging:3.0.0-wasm2"
+
 androidxLifecycleLivedataKtx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycle" }
 androidxLifecycleRuntimeKtx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidxLifecycleViewmodelKtx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ kotlinxCoroutineTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test
 
 ktorCore = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktorCio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
-ktorCoreJs = { module = "io.ktor:ktor-client-core-wasm-js", version.ref = "ktor" }
+ktorCoreJs = { module = "io.ktor:ktor-client-core-js", version.ref = "ktor" }
 ktorClientJsWasmJs = { module = "io.ktor:ktor-client-js-wasm-js", version.ref = "ktor" }
 ktorClientAndroid = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
 ktorClientLogging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ ksp = "2.0.0-1.0.22"
 javaVersion = "17"
 
 coroutine = "1.9.0-RC"
-ktor = "3.2.0"
+ktor = "3.0.0-wasm2"
 lifecycle = "2.5.1"
 koin = "3.6.0-wasm-alpha2"
 koinAnnotation = "1.3.1"
@@ -30,11 +30,11 @@ kotlinxCoroutineAndroid = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-a
 kotlinxCoroutineTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutine" }
 
 ktorCore = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
-ktorCio = { module = "io.ktor:ktor-client-cio", version = "3.0.0-wasm2" }
+ktorCio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktorCoreJs = { module = "io.ktor:ktor-client-core-wasm-js", version.ref = "ktor" }
-ktorClientJsWasmJs = "io.ktor:ktor-client-js-wasm-js:3.2.0"
-ktorClientAndroid = "io.ktor:ktor-client-android:3.0.0-wasm2"
-ktorClientLogging = "io.ktor:ktor-client-logging:3.0.0-wasm2"
+ktorClientJsWasmJs = { module = "io.ktor:ktor-client-js-wasm-js", version.ref = "ktor" }
+ktorClientAndroid = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
+ktorClientLogging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 
 androidxLifecycleLivedataKtx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycle" }
 androidxLifecycleRuntimeKtx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }

--- a/kmpShare/build.gradle.kts
+++ b/kmpShare/build.gradle.kts
@@ -18,6 +18,17 @@ kotlin {
         }
     }
 
+    js(IR) {
+        useCommonJs()
+        browser {
+            commonWebpackConfig {
+            }
+            binaries.executable()
+        }
+        nodejs {
+        }
+    }
+
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         browser {
@@ -63,6 +74,8 @@ kotlin {
 
             implementation(libs.koinAndroid)
             implementation(libs.voyagerKoin)
+        }
+        jsMain.dependencies {
         }
         wasmJsMain.dependencies {
             implementation(libs.ktorCoreJs)

--- a/kmpShare/build.gradle.kts
+++ b/kmpShare/build.gradle.kts
@@ -50,6 +50,7 @@ kotlin {
             api(libs.kotlinxDatetime)
             implementation(libs.kotlinxCoroutineCore)
             implementation(libs.ktorCore)
+            implementation(libs.ktorClientLogging)
             implementation(libs.kotlinxSerializationJson)
 
             implementation(libs.koinCore)

--- a/kmpShare/build.gradle.kts
+++ b/kmpShare/build.gradle.kts
@@ -78,6 +78,7 @@ kotlin {
         }
         jsMain.dependencies {
             implementation(libs.ktorCoreJs)
+            implementation(libs.kotlinxCoroutineCoreJs)
         }
         wasmJsMain.dependencies {
             implementation(libs.ktorClientJsWasmJs)

--- a/kmpShare/build.gradle.kts
+++ b/kmpShare/build.gradle.kts
@@ -77,9 +77,9 @@ kotlin {
             implementation(libs.voyagerKoin)
         }
         jsMain.dependencies {
+            implementation(libs.ktorCoreJs)
         }
         wasmJsMain.dependencies {
-            implementation(libs.ktorCoreJs)
             implementation(libs.ktorClientJsWasmJs)
         }
     }

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/di/NetworkModule.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/di/NetworkModule.kt
@@ -2,13 +2,14 @@ package jp.co.yumemi.codecheck.di
 
 import io.ktor.client.HttpClient
 import jp.co.yumemi.codecheck.api.SearchClient
+import jp.co.yumemi.codecheck.httpClient
 import kotlinx.serialization.json.Json
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
 val networkModule = module {
     single<HttpClient> {
-        HttpClient()
+        httpClient()
     }
     single<Json> {
         Json {

--- a/kmpShare/src/jsMain/kotlin/jp/co/yumemi/codecheck/Platform.js.kt
+++ b/kmpShare/src/jsMain/kotlin/jp/co/yumemi/codecheck/Platform.js.kt
@@ -1,0 +1,14 @@
+package jp.co.yumemi.codecheck
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.js.JsClient
+
+private val platform = object : Platform {
+    override val name: String
+        get() = "Kotlin/JS it's JavaScript!?"
+}
+
+actual fun httpClient(config: HttpClientConfig<*>.() -> Unit): HttpClient = HttpClient(JsClient())
+
+actual fun getPlatform(): Platform = platform

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -2554,7 +2554,7 @@ source-map-loader@5.0.0:
     iconv-lite "^0.6.3"
     source-map-js "^1.0.2"
 
-source-map-support@~0.5.20:
+source-map-support@0.5.21, source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==


### PR DESCRIPTION
close #83 

https://youtrack.jetbrains.com/issue/KTOR-7054/NoSuchMethodError-when-using-coroutines-1.9.0-RC

coroutinesのバージョンを1.8.1に戻すと解消された
ぐぐるのではなく、issueから探す方が早いことがよく分かった

検索はできるようになった
ただWebで詳細画面に一旦移動すると検索画面に戻ることができない
BackHandlerがVoyagerに搭載されているものの、Webからそれを発火する方法がないように思う

また、アプリで表示している日本語文字がWebだと文字化けしている（豆腐になる）