### PR TITLE
RenovateのConfigを見直し

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,6 @@ javaVersion = "17"
 
 coroutine = "1.8.1"
 ktor = "3.0.0-wasm2"
-lifecycle = "2.5.1"
 koin = "3.6.0-wasm-alpha2"
 koinAnnotation = "1.3.1"
 voyager = "1.1.0-beta02"
@@ -14,7 +13,6 @@ coil3 = "3.0.0-alpha06"
 roborazzi = "1.20.0"
 
 [libraries]
-coilCompose = { module = "io.coil-kt:coil-compose", version = "2.6.0" }
 coil3ComposeCore = { module = "io.coil-kt.coil3:coil-compose-core", version.ref = "coil3" }
 coil3NetworkKtor = { module = "io.coil-kt.coil3:coil-network-ktor", version.ref = "coil3" }
 
@@ -39,13 +37,11 @@ ktorClientLogging = { module = "io.ktor:ktor-client-logging", version.ref = "kto
 ktorClientContentNegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktorClientSerialization = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 
-androidxLifecycleLivedataKtx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycle" }
-androidxLifecycleRuntimeKtx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
-androidxLifecycleViewmodelKtx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotestAssertion = { module = "io.kotest:kotest-assertions-core", version = "5.9.1" }
 kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.7.0" }
 kotlinxDatetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.6.0" }
+
 koinCore = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koinTest = { module = "io.insert-koin:koin-test", version.ref = "koin" }
 koinAndroid = { module = "io.insert-koin:koin-android", version.ref = "koin" }

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,9 @@
   ],
   "ignoreDeps": [
     "kotlin",
-    "gradle"
+    "gradle",
+    "com.android.library",
+    "com.android.application"
   ],
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,10 @@
   "labels": [
     "dependencies"
   ],
+  "ignoreDeps": [
+    "kotlin",
+    "gradle"
+  ],
   "packageRules": [
     {
       "matchUpdateTypes": [
@@ -21,12 +25,6 @@
       ],
       "groupName": "patch version up",
       "automerge": true
-    },
-    {
-      "excludePackageNames": [
-        "kotlin",
-        "gradle"
-      ]
     }
   ]
 }


### PR DESCRIPTION
close #94 

- renovateのコンフィグを見直し
- KotlinとGradleのバージョンはrenovateでアップデートしないようにした
- libs.versions.tomlから使っていないライブラリ宣言を削除した