### PR TITLE
UIからロジックをScreenModelへ移行

### DIFF
--- a/app/src/test/kotlin/jp/co/yumemi/android/codecheck/ui/ComposeTestSample.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/codecheck/ui/ComposeTestSample.kt
@@ -1,12 +1,11 @@
 package jp.co.yumemi.android.codecheck.ui
 
-import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
 import jp.co.yumemi.codecheck.App
 import kotlinx.coroutines.test.runTest
@@ -41,7 +40,7 @@ class ComposeTestSample {
         composeRule.onNodeWithTag("edit")
             .performTextInput("gen0083")
         composeRule.onNodeWithTag("edit")
-            .performKeyInput { keyDown(Key.Search) }
+            .performImeAction()
         composeRule.waitUntilAtLeastOneExists(hasTestTag("result"), 3000)
         composeRule.onNode(hasText("gen0083/textlint-myrule"))
             .assertExists()

--- a/kmpShare/src/androidUnitTest/kotlin/jp/co/yumemi/codecheck/ui/ComposeTestSample.kt
+++ b/kmpShare/src/androidUnitTest/kotlin/jp/co/yumemi/codecheck/ui/ComposeTestSample.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.printToLog
 import com.github.takahirom.roborazzi.captureRoboImage
@@ -49,7 +50,11 @@ class ComposeTestSample {
         // テキスト入力しただけでrecompositionは発生しない
         composeRule.onNodeWithTag("edit")
             .performTextInput("gen0083")
-        // composeRuleでなにかするとrecompositionが起こる
+        // テキスト入力から一定時間経ったら検索がトリガーされる、という処理はどうやってテストすればいいかわからなかった
+        // SearchTextFieldにImeActionを登録してからperformImeActionを送ることで検索がトリガーされるようになった
+        composeRule.onNodeWithTag("edit")
+            .performImeAction()
+        // composeRuleでなにかするとrecompositionが起こる? この辺イマイチ理解していない・・・
         // https://developer.android.com/develop/ui/compose/testing/synchronization
         composeRule.waitUntilAtLeastOneExists(
             hasTestTag("result"),

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/components/SearchTextField.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/components/SearchTextField.kt
@@ -1,0 +1,115 @@
+package jp.co.yumemi.codecheck.ui.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text2.BasicTextField2
+import androidx.compose.foundation.text2.TextFieldDecorator
+import androidx.compose.foundation.text2.input.TextFieldLineLimits
+import androidx.compose.foundation.text2.input.TextFieldState
+import androidx.compose.foundation.text2.input.clearText
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.layout.LastBaseline
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import jp.co.yumemi.codecheck.resources.Res
+import jp.co.yumemi.codecheck.resources.searchInputText_hint
+import org.jetbrains.compose.resources.stringResource
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun SearchTextField(
+    textState: TextFieldState,
+    onTextChanged: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BasicTextField2(
+        state = textState,
+        lineLimits = TextFieldLineLimits.SingleLine,
+        keyboardActions = KeyboardActions(
+            onSend = { onTextChanged(textState.text.toString()) },
+            onSearch = { onTextChanged(textState.text.toString()) },
+            onDone = { onTextChanged(textState.text.toString()) },
+        ),
+        decorator = TextFieldDecorator { innerTextField ->
+            Row(
+                modifier = Modifier
+                    .background(MaterialTheme.colorScheme.background)
+                    .fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Search,
+                    contentDescription = "",
+                    tint = MaterialTheme.colorScheme.onBackground,
+                    modifier = Modifier.minimumInteractiveComponentSize(),
+                )
+                Box(modifier = Modifier.weight(1f)) {
+                    innerTextField()
+                    if (textState.text.isBlank()) {
+                        Text(
+                            text = stringResource(Res.string.searchInputText_hint),
+                            color = MaterialTheme.colorScheme.onBackground,
+                            style = TextStyle(
+                                color = MaterialTheme.colorScheme.onBackground,
+                                fontSize = 20.sp,
+                            ),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+                if (textState.text.isNotBlank()) {
+                    IconButton(
+                        onClick = {
+                            textState.clearText()
+                        },
+                        colors = IconButtonDefaults.iconButtonColors(),
+                        modifier = Modifier
+                            .alignBy(LastBaseline),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Clear,
+                            contentDescription = "delete",
+                            tint = MaterialTheme.colorScheme.onBackground,
+                        )
+                    }
+                }
+            }
+        },
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+            .border(
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+                shape = RoundedCornerShape(4.dp),
+            )
+            .padding(8.dp),
+        textStyle = TextStyle(
+            color = MaterialTheme.colorScheme.onBackground,
+            fontSize = 20.sp,
+        ),
+        cursorBrush = SolidColor(MaterialTheme.colorScheme.onBackground),
+    )
+}

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/components/SearchTextField.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/components/SearchTextField.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text2.BasicTextField2
 import androidx.compose.foundation.text2.TextFieldDecorator
 import androidx.compose.foundation.text2.input.TextFieldLineLimits
@@ -30,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.LastBaseline
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -47,6 +49,7 @@ fun SearchTextField(
     BasicTextField2(
         state = textState,
         lineLimits = TextFieldLineLimits.SingleLine,
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
         keyboardActions = KeyboardActions(
             onSend = { onTriggerSearch(textState.text.toString()) },
             onSearch = { onTriggerSearch(textState.text.toString()) },

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/components/SearchTextField.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/components/SearchTextField.kt
@@ -41,16 +41,16 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun SearchTextField(
     textState: TextFieldState,
-    onTextChanged: (String) -> Unit,
+    onTriggerSearch: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     BasicTextField2(
         state = textState,
         lineLimits = TextFieldLineLimits.SingleLine,
         keyboardActions = KeyboardActions(
-            onSend = { onTextChanged(textState.text.toString()) },
-            onSearch = { onTextChanged(textState.text.toString()) },
-            onDone = { onTextChanged(textState.text.toString()) },
+            onSend = { onTriggerSearch(textState.text.toString()) },
+            onSearch = { onTriggerSearch(textState.text.toString()) },
+            onDone = { onTriggerSearch(textState.text.toString()) },
         ),
         decorator = TextFieldDecorator { innerTextField ->
             Row(

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchContent.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchContent.kt
@@ -29,14 +29,14 @@ fun SearchContent(
     list: List<RepositoryInfo>,
     isLoading: Boolean,
     textState: TextFieldState,
-    onTextChanged: (String) -> Unit,
+    onTriggerSearch: (String) -> Unit,
     onNavigate: (RepositoryInfo) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.imePadding()) {
         SearchTextField(
             textState = textState,
-            onTextChanged = onTextChanged,
+            onTriggerSearch = onTriggerSearch,
             modifier = Modifier.testTag("edit"),
         )
         Box(

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchContent.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchContent.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.text2.input.rememberTextFieldState
+import androidx.compose.foundation.text2.input.TextFieldState
 import androidx.compose.foundation.text2.input.textAsFlow
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
@@ -32,11 +32,11 @@ import kotlinx.coroutines.launch
 fun SearchContent(
     list: List<RepositoryInfo>,
     isLoading: Boolean,
+    textState: TextFieldState,
     onTextChanged: (String) -> Unit,
     onNavigate: (RepositoryInfo) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val textState = rememberTextFieldState("")
     LaunchedEffect(Unit) {
         this.launch {
             textState.textAsFlow().debounce(1000).collect {

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchContent.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchContent.kt
@@ -11,21 +11,17 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text2.input.TextFieldState
-import androidx.compose.foundation.text2.input.textAsFlow
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import jp.co.yumemi.codecheck.api.RepositoryInfo
 import jp.co.yumemi.codecheck.ui.components.SearchTextField
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -37,13 +33,6 @@ fun SearchContent(
     onNavigate: (RepositoryInfo) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LaunchedEffect(Unit) {
-        this.launch {
-            textState.textAsFlow().debounce(1000).collect {
-                onTextChanged(it.toString())
-            }
-        }
-    }
     Column(modifier = modifier.imePadding()) {
         SearchTextField(
             textState = textState,

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchContent.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchContent.kt
@@ -1,57 +1,31 @@
 package jp.co.yumemi.codecheck.ui.search
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text2.BasicTextField2
-import androidx.compose.foundation.text2.TextFieldDecorator
-import androidx.compose.foundation.text2.input.TextFieldLineLimits
-import androidx.compose.foundation.text2.input.TextFieldState
-import androidx.compose.foundation.text2.input.clearText
 import androidx.compose.foundation.text2.input.rememberTextFieldState
 import androidx.compose.foundation.text2.input.textAsFlow
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Clear
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.layout.LastBaseline
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import jp.co.yumemi.codecheck.api.RepositoryInfo
-import jp.co.yumemi.codecheck.resources.Res
-import jp.co.yumemi.codecheck.resources.searchInputText_hint
+import jp.co.yumemi.codecheck.ui.components.SearchTextField
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
-import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -113,81 +87,4 @@ fun SearchContent(
             }
         }
     }
-}
-
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-fun SearchTextField(
-    textState: TextFieldState,
-    onTextChanged: (String) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    BasicTextField2(
-        state = textState,
-        lineLimits = TextFieldLineLimits.SingleLine,
-        keyboardActions = KeyboardActions(
-            onSend = { onTextChanged(textState.text.toString()) },
-            onSearch = { onTextChanged(textState.text.toString()) },
-            onDone = { onTextChanged(textState.text.toString()) },
-        ),
-        decorator = TextFieldDecorator { innerTextField ->
-            Row(
-                modifier = Modifier
-                    .background(MaterialTheme.colorScheme.background)
-                    .fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Search,
-                    contentDescription = "",
-                    tint = MaterialTheme.colorScheme.onBackground,
-                    modifier = Modifier.minimumInteractiveComponentSize(),
-                )
-                Box(modifier = Modifier.weight(1f)) {
-                    innerTextField()
-                    if (textState.text.isBlank()) {
-                        Text(
-                            text = stringResource(Res.string.searchInputText_hint),
-                            color = MaterialTheme.colorScheme.onBackground,
-                            style = TextStyle(
-                                color = MaterialTheme.colorScheme.onBackground,
-                                fontSize = 20.sp,
-                            ),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
-                }
-                if (textState.text.isNotBlank()) {
-                    IconButton(
-                        onClick = {
-                            textState.clearText()
-                        },
-                        colors = IconButtonDefaults.iconButtonColors(),
-                        modifier = Modifier
-                            .alignBy(LastBaseline),
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Clear,
-                            contentDescription = "delete",
-                            tint = MaterialTheme.colorScheme.onBackground,
-                        )
-                    }
-                }
-            }
-        },
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(16.dp)
-            .border(
-                border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
-                shape = RoundedCornerShape(4.dp),
-            )
-            .padding(8.dp),
-        textStyle = TextStyle(
-            color = MaterialTheme.colorScheme.onBackground,
-            fontSize = 20.sp,
-        ),
-        cursorBrush = SolidColor(MaterialTheme.colorScheme.onBackground),
-    )
 }

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreen.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreen.kt
@@ -1,6 +1,8 @@
 package jp.co.yumemi.codecheck.ui.search
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text2.input.rememberTextFieldState
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -15,6 +17,7 @@ import jp.co.yumemi.codecheck.ui.detail.RepositoryDetailScreen
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
+@ExperimentalFoundationApi
 class SearchScreen : Screen, KoinComponent {
     @Composable
     override fun Content() {
@@ -23,6 +26,7 @@ class SearchScreen : Screen, KoinComponent {
             inject<SearchScreenModel>().value
         }
         val state by screenModel.state.collectAsState()
+        val textFieldState = rememberTextFieldState(initialText = "")
 
         Scaffold(
             topBar = {
@@ -35,6 +39,7 @@ class SearchScreen : Screen, KoinComponent {
             SearchContent(
                 list = state.list,
                 isLoading = state.isLoading,
+                textState = textFieldState,
                 onTextChanged = { screenModel.searchResults(it) },
                 onNavigate = { navigator.push(RepositoryDetailScreen(it)) },
                 modifier = Modifier.padding(paddingValues = it),

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreen.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreen.kt
@@ -2,7 +2,6 @@ package jp.co.yumemi.codecheck.ui.search
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text2.input.rememberTextFieldState
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -24,11 +23,8 @@ class SearchScreen : Screen, KoinComponent {
     @Composable
     override fun Content() {
         val navigator = LocalNavigator.currentOrThrow
-        val textFieldState = rememberTextFieldState(initialText = "")
         val screenModel = rememberScreenModel<SearchScreenModel> {
-            val screenModel = inject<SearchScreenModel>().value
-            screenModel.connectTextFieldState(textFieldState)
-            screenModel
+            inject<SearchScreenModel>().value
         }
         val state by screenModel.state.collectAsState()
 
@@ -43,7 +39,7 @@ class SearchScreen : Screen, KoinComponent {
             SearchContent(
                 list = state.list,
                 isLoading = state.isLoading,
-                textState = textFieldState,
+                textState = screenModel.textFieldState,
                 onTextChanged = { screenModel.searchResults(it) },
                 onNavigate = { navigator.push(RepositoryDetailScreen(it)) },
                 modifier = Modifier.padding(paddingValues = it),

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreen.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreen.kt
@@ -14,9 +14,11 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import jp.co.yumemi.codecheck.ui.components.MyTopAppBar
 import jp.co.yumemi.codecheck.ui.detail.RepositoryDetailScreen
+import kotlinx.coroutines.FlowPreview
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
+@FlowPreview
 @ExperimentalFoundationApi
 class SearchScreen : Screen, KoinComponent {
     @Composable
@@ -27,6 +29,8 @@ class SearchScreen : Screen, KoinComponent {
         }
         val state by screenModel.state.collectAsState()
         val textFieldState = rememberTextFieldState(initialText = "")
+
+        screenModel.connectTextFieldState(textFieldState)
 
         Scaffold(
             topBar = {

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreen.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreen.kt
@@ -40,7 +40,7 @@ class SearchScreen : Screen, KoinComponent {
                 list = state.list,
                 isLoading = state.isLoading,
                 textState = screenModel.textFieldState,
-                onTriggerSearch = { screenModel.searchResults(it) },
+                onTriggerSearch = { screenModel.searchRepository(it) },
                 onNavigate = { navigator.push(RepositoryDetailScreen(it)) },
                 modifier = Modifier.padding(paddingValues = it),
             )

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreen.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreen.kt
@@ -18,9 +18,9 @@ import kotlinx.coroutines.FlowPreview
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-@FlowPreview
-@ExperimentalFoundationApi
 class SearchScreen : Screen, KoinComponent {
+    @FlowPreview
+    @ExperimentalFoundationApi
     @Composable
     override fun Content() {
         val navigator = LocalNavigator.currentOrThrow

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreen.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreen.kt
@@ -40,7 +40,7 @@ class SearchScreen : Screen, KoinComponent {
                 list = state.list,
                 isLoading = state.isLoading,
                 textState = screenModel.textFieldState,
-                onTextChanged = { screenModel.searchResults(it) },
+                onTriggerSearch = { screenModel.searchResults(it) },
                 onNavigate = { navigator.push(RepositoryDetailScreen(it)) },
                 modifier = Modifier.padding(paddingValues = it),
             )

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreen.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreen.kt
@@ -24,13 +24,13 @@ class SearchScreen : Screen, KoinComponent {
     @Composable
     override fun Content() {
         val navigator = LocalNavigator.currentOrThrow
+        val textFieldState = rememberTextFieldState(initialText = "")
         val screenModel = rememberScreenModel<SearchScreenModel> {
-            inject<SearchScreenModel>().value
+            val screenModel = inject<SearchScreenModel>().value
+            screenModel.connectTextFieldState(textFieldState)
+            screenModel
         }
         val state by screenModel.state.collectAsState()
-        val textFieldState = rememberTextFieldState(initialText = "")
-
-        screenModel.connectTextFieldState(textFieldState)
 
         Scaffold(
             topBar = {

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreenModel.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreenModel.kt
@@ -3,13 +3,22 @@
  */
 package jp.co.yumemi.codecheck.ui.search
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.text2.input.TextFieldState
+import androidx.compose.foundation.text2.input.textAsFlow
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import jp.co.yumemi.codecheck.api.RepositoryInfo
 import jp.co.yumemi.codecheck.api.SearchClient
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
+@FlowPreview
+@ExperimentalFoundationApi
 class SearchScreenModel(
     private val searchClient: SearchClient,
 ) : StateScreenModel<SearchScreenModel.State>(State()) {
@@ -30,6 +39,17 @@ class SearchScreenModel(
                     isLoading = false,
                 )
             }
+        }
+    }
+
+    fun connectTextFieldState(state: TextFieldState) {
+        screenModelScope.launch {
+            state.textAsFlow()
+                .debounce(1000)
+                .distinctUntilChanged { old, new -> old.toString() == new.toString() }
+                .collectLatest {
+                    searchResults(it.toString())
+                }
         }
     }
 }

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreenModel.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreenModel.kt
@@ -17,8 +17,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-@FlowPreview
-@ExperimentalFoundationApi
 class SearchScreenModel(
     private val searchClient: SearchClient,
 ) : StateScreenModel<SearchScreenModel.State>(State()) {
@@ -42,6 +40,8 @@ class SearchScreenModel(
         }
     }
 
+    @FlowPreview
+    @ExperimentalFoundationApi
     fun connectTextFieldState(state: TextFieldState) {
         screenModelScope.launch {
             state.textAsFlow()

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreenModel.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreenModel.kt
@@ -36,13 +36,13 @@ class SearchScreenModel(
                 .debounce(1000)
                 .distinctUntilChanged { old, new -> new.contentEquals(old) }
                 .collectLatest {
-                    searchResults(it.toString())
+                    searchRepository(it.toString())
                 }
         }
     }
 
     // 検索結果
-    fun searchResults(inputText: String) {
+    fun searchRepository(inputText: String) {
         if (previousQuery == inputText) return
         if (inputText.isBlank()) return
         previousQuery = inputText

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreenModel.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreenModel.kt
@@ -26,9 +26,13 @@ class SearchScreenModel(
         val isLoading: Boolean = false,
     )
 
+    private var previousQuery: String = ""
+
     // 検索結果
     fun searchResults(inputText: String) {
+        if (previousQuery == inputText) return
         if (inputText.isBlank()) return
+        previousQuery = inputText
         screenModelScope.launch {
             mutableState.update { it.copy(isLoading = true) }
             mutableState.update {

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreenModel.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/search/SearchScreenModel.kt
@@ -34,7 +34,7 @@ class SearchScreenModel(
         screenModelScope.launch {
             textFieldState.textAsFlow()
                 .debounce(1000)
-                .distinctUntilChanged { old, new -> old.toString() == new.toString() }
+                .distinctUntilChanged { old, new -> new.contentEquals(old) }
                 .collectLatest {
                     searchResults(it.toString())
                 }


### PR DESCRIPTION
- close #103 
- close #78 

# 概要

UIのLaunchedEffectでtextAsFlowの購読をしている部分をScreenModelにState hoistingしてみた
検索をトリガーする処理が、KeyboardActionと時間経過の2つがあるため、同じ検索クエリでも即座に発動→時間経過で発動ということが起こる
それを回避するため、ScreenModelで検索を行ったクエリを保持するようにして、同じなら検索しないようにした
この変更によりそれまで動いていたテストが壊れてしまった
LauncedEffectを使っていたためComposable内時間で処理が行われていたが、Composable外で検索処理がトリガーされるようになったためという理解

ComposeのテストのmainClockの概念がよくわからん・・・

関数名などの名前の改善も行った
