### PR TITLE
Actionsで使っているgradleセットアップスクリプトのDeprecated対応

### DIFF
--- a/.github/workflows/compare_screenshot.yml
+++ b/.github/workflows/compare_screenshot.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/compare_screenshot.yml
+++ b/.github/workflows/compare_screenshot.yml
@@ -28,7 +28,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@4c39dd82cd5e1ec7c6fa0173bb41b4b6bb3b86ff # v3.3.2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: wrapper
 

--- a/.github/workflows/compare_screenshot_comment.yml
+++ b/.github/workflows/compare_screenshot_comment.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
+      - uses: dawidd6/action-download-artifact@v3
         with:
           name: pr
           run_id: ${{ github.event.workflow_run.id }}
@@ -47,7 +47,7 @@ jobs:
           git branch -D "$BRANCH_NAME" || true
           git checkout --orphan "$BRANCH_NAME"
           git rm -rf .
-      - uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
+      - uses: dawidd6/action-download-artifact@v3
         with:
           run_id: ${{ github.event.workflow_run.id }}
           name: screenshot-diff

--- a/.github/workflows/store_screenshot.yml
+++ b/.github/workflows/store_screenshot.yml
@@ -29,7 +29,7 @@ jobs:
 
       # Better than caching and/or extensions of actions/setup-java
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@4c39dd82cd5e1ec7c6fa0173bb41b4b6bb3b86ff # v3.3.2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: wrapper
 

--- a/.github/workflows/store_screenshot.yml
+++ b/.github/workflows/store_screenshot.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17


### PR DESCRIPTION
以下のDeprecatedに対応するためのPR

## Deprecation warnings

This job uses deprecated functionality from the gradle/gradle-build-action action. Follow the links for upgrade details.
[The action `gradle/gradle-build-action` has been replaced by `gradle/actions/setup-gradle`](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle)