### PR TITLE
各画面をキャプチャするテストを追加

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,8 @@ coil3 = "3.0.0-alpha06"
 roborazzi = "1.20.0"
 
 [libraries]
+coil3 = { module = "io.coil-kt.coil3:coil", version.ref = "coil3" }
+coil3Compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil3" }
 coil3Core = { module = "io.coil-kt.coil3:coil-core", version.ref = "coil3" }
 coil3ComposeCore = { module = "io.coil-kt.coil3:coil-compose-core", version.ref = "coil3" }
 coil3ComposeAndroid = { module = "io.coil-kt.coil3:coil-compose-android", version.ref = "coil3" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,8 +13,11 @@ coil3 = "3.0.0-alpha06"
 roborazzi = "1.20.0"
 
 [libraries]
+coil3Core = { module = "io.coil-kt.coil3:coil-core", version.ref = "coil3" }
 coil3ComposeCore = { module = "io.coil-kt.coil3:coil-compose-core", version.ref = "coil3" }
+coil3ComposeAndroid = { module = "io.coil-kt.coil3:coil-compose-android", version.ref = "coil3" }
 coil3NetworkKtor = { module = "io.coil-kt.coil3:coil-network-ktor", version.ref = "coil3" }
+coil3Test = { module = "io.coil-kt.coil3:coil-test", version.ref = "coil3" }
 
 desugar = { module = "com.android.tools:desugar_jdk_libs", version = "2.0.4" }
 androidxCoreKtx = { module = "androidx.core:core-ktx", version = "1.13.1" }

--- a/kmpShare/build.gradle.kts
+++ b/kmpShare/build.gradle.kts
@@ -56,6 +56,7 @@ kotlin {
 
             implementation(libs.koinCore)
 
+            implementation(libs.coil3Core)
             implementation(libs.coil3ComposeCore)
             implementation(libs.coil3NetworkKtor)
 
@@ -69,6 +70,7 @@ kotlin {
 
             implementation(libs.koinTest)
             implementation(libs.kotlinxCoroutineTest)
+            implementation(libs.coil3Test)
         }
         androidMain.dependencies {
             implementation(libs.kotlinxCoroutineAndroid)
@@ -76,6 +78,7 @@ kotlin {
 
             implementation(libs.koinAndroid)
             implementation(libs.voyagerKoin)
+            implementation(libs.coil3ComposeAndroid)
         }
         jsMain.dependencies {
             implementation(libs.ktorCoreJs)

--- a/kmpShare/build.gradle.kts
+++ b/kmpShare/build.gradle.kts
@@ -56,6 +56,8 @@ kotlin {
 
             implementation(libs.koinCore)
 
+            implementation(libs.coil3)
+            implementation(libs.coil3Compose)
             implementation(libs.coil3Core)
             implementation(libs.coil3ComposeCore)
             implementation(libs.coil3NetworkKtor)

--- a/kmpShare/build.gradle.kts
+++ b/kmpShare/build.gradle.kts
@@ -103,6 +103,9 @@ android {
         sourceCompatibility = JavaVersion.toVersion(libs.versions.javaVersion.get())
         targetCompatibility = JavaVersion.toVersion(libs.versions.javaVersion.get())
     }
+    buildFeatures {
+        compose = true
+    }
     testOptions.unitTests.isIncludeAndroidResources = true
 
     dependencies {

--- a/kmpShare/src/androidMain/kotlin/jp/co/yumemi/codecheck/ui/components/MyTopAppBarPreview.kt
+++ b/kmpShare/src/androidMain/kotlin/jp/co/yumemi/codecheck/ui/components/MyTopAppBarPreview.kt
@@ -2,9 +2,11 @@ package jp.co.yumemi.codecheck.ui.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import jp.co.yumemi.codecheck.ui.theme.AppTheme
 
 @Preview
+@PreviewLightDark
 @Composable
 private fun MyTopAppBarPreview() {
     AppTheme {

--- a/kmpShare/src/androidUnitTest/kotlin/jp/co/yumemi/codecheck/ui/ComposeTestSample.kt
+++ b/kmpShare/src/androidUnitTest/kotlin/jp/co/yumemi/codecheck/ui/ComposeTestSample.kt
@@ -66,7 +66,7 @@ class ComposeTestSample {
         composeRule.onRoot().printToLog("test")
         // キャプチャを取る→すでに画像が存在している場合、画像に変化がある場合にテストに失敗する
         composeRule.onRoot()
-            .captureRoboImage("build/compose.png")
+            .captureRoboImage()
         composeRule.onNode(hasText("gen0083/textlint-myrule"))
             .assertExists()
     }

--- a/kmpShare/src/androidUnitTest/kotlin/jp/co/yumemi/codecheck/ui/ComposeTestSample.kt
+++ b/kmpShare/src/androidUnitTest/kotlin/jp/co/yumemi/codecheck/ui/ComposeTestSample.kt
@@ -10,6 +10,8 @@ import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.printToLog
+import com.github.takahirom.roborazzi.RoborazziRule
+import com.github.takahirom.roborazzi.captureRoboGif
 import com.github.takahirom.roborazzi.captureRoboImage
 import jp.co.yumemi.codecheck.App
 import kotlinx.coroutines.test.runTest
@@ -25,6 +27,13 @@ import org.robolectric.shadows.ShadowLog
 class ComposeTestSample {
     @get:Rule
     val composeRule = createComposeRule()
+
+    @get:Rule
+    val roborazziRule = RoborazziRule(
+        options = RoborazziRule.Options(
+            captureType = RoborazziRule.CaptureType.LastImage(onlyFail = true),
+        ),
+    )
 
     @Test
     fun test() {
@@ -46,28 +55,29 @@ class ComposeTestSample {
         ShadowLog.stream = System.out
         Log.d("a", "Log.d print message")
         composeRule.setContent { App() }
-        composeRule.awaitIdle()
-        // テキスト入力しただけでrecompositionは発生しない
-        composeRule.onNodeWithTag("edit")
-            .performTextInput("gen0083")
-        // テキスト入力から一定時間経ったら検索がトリガーされる、という処理はどうやってテストすればいいかわからなかった
-        // SearchTextFieldにImeActionを登録してからperformImeActionを送ることで検索がトリガーされるようになった
-        composeRule.onNodeWithTag("edit")
-            .performImeAction()
-        // composeRuleでなにかするとrecompositionが起こる? この辺イマイチ理解していない・・・
-        // https://developer.android.com/develop/ui/compose/testing/synchronization
-        composeRule.waitUntilAtLeastOneExists(
-            hasTestTag("result"),
-            5_000,
-        )
-        // Roborazziが画像で出してくれるけども、テキストで確認したい場合はprintToLogが使える
-        // ただし中身はLog.dでログに出力しているのでRobolectricを使う場合はログの切り替えをしないと何も出力されない
-        // 引数に渡すタグはLog.dで使われるタグ
-        composeRule.onRoot().printToLog("test")
-        // キャプチャを取る→すでに画像が存在している場合、画像に変化がある場合にテストに失敗する
-        composeRule.onRoot()
-            .captureRoboImage()
-        composeRule.onNode(hasText("gen0083/textlint-myrule"))
-            .assertExists()
+        composeRule.onRoot().captureRoboGif(composeRule) {
+            // テキスト入力しただけでrecompositionは発生しない
+            composeRule.onNodeWithTag("edit")
+                .performTextInput("gen0083")
+            // テキスト入力から一定時間経ったら検索がトリガーされる、という処理はどうやってテストすればいいかわからなかった
+            // SearchTextFieldにImeActionを登録してからperformImeActionを送ることで検索がトリガーされるようになった
+            composeRule.onNodeWithTag("edit")
+                .performImeAction()
+            // composeRuleでなにかするとrecompositionが起こる? この辺イマイチ理解していない・・・
+            // https://developer.android.com/develop/ui/compose/testing/synchronization
+            composeRule.waitUntilAtLeastOneExists(
+                hasTestTag("result"),
+                5_000,
+            )
+            // Roborazziが画像で出してくれるけども、テキストで確認したい場合はprintToLogが使える
+            // ただし中身はLog.dでログに出力しているのでRobolectricを使う場合はログの切り替えをしないと何も出力されない
+            // 引数に渡すタグはLog.dで使われるタグ
+            composeRule.onRoot().printToLog("test")
+            // キャプチャを取る→すでに画像が存在している場合、画像に変化がある場合にテストに失敗する
+            composeRule.onRoot()
+                .captureRoboImage()
+            composeRule.onNode(hasText("gen0083/textlint-myrule"))
+                .assertExists()
+        }
     }
 }

--- a/kmpShare/src/androidUnitTest/kotlin/jp/co/yumemi/codecheck/ui/detail/RepositoryDetailContentTest.kt
+++ b/kmpShare/src/androidUnitTest/kotlin/jp/co/yumemi/codecheck/ui/detail/RepositoryDetailContentTest.kt
@@ -1,0 +1,46 @@
+package jp.co.yumemi.codecheck.ui.detail
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import com.github.takahirom.roborazzi.captureRoboImage
+import jp.co.yumemi.codecheck.api.RepositoryInfo
+import jp.co.yumemi.codecheck.api.RepositoryOwner
+import jp.co.yumemi.codecheck.ui.theme.AppTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class RepositoryDetailContentTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun default() {
+        composeRule.setContent {
+            AppTheme {
+                RepositoryDetailContent(
+                    info = RepositoryInfo(
+                        name = "default/some",
+                        owner = RepositoryOwner(
+                            ownerIconUrl = "",
+                        ),
+                        language = "kotlin",
+                        stargazersCount = 10,
+                        watchersCount = 1,
+                        forksCount = 100,
+                        openIssuesCount = 1111,
+                    ),
+                    lastSearchDate = "検索日: 2024年1月1日 01:02:03",
+                )
+            }
+        }
+        composeRule.onNodeWithText("default")
+            .assertExists()
+        composeRule.onRoot().captureRoboImage()
+    }
+}

--- a/kmpShare/src/androidUnitTest/kotlin/jp/co/yumemi/codecheck/ui/detail/RepositoryDetailContentTest.kt
+++ b/kmpShare/src/androidUnitTest/kotlin/jp/co/yumemi/codecheck/ui/detail/RepositoryDetailContentTest.kt
@@ -1,17 +1,29 @@
 package jp.co.yumemi.codecheck.ui.detail
 
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import androidx.compose.foundation.background
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.compose.LocalPlatformContext
+import coil3.test.FakeImage
+import coil3.test.FakeImageLoaderEngine
+import coil3.test.default
 import com.github.takahirom.roborazzi.captureRoboImage
 import jp.co.yumemi.codecheck.api.RepositoryInfo
 import jp.co.yumemi.codecheck.api.RepositoryOwner
 import jp.co.yumemi.codecheck.ui.theme.AppTheme
+import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.GraphicsMode
+import org.robolectric.shadows.ShadowLog
 
 @RunWith(RobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
@@ -20,14 +32,26 @@ class RepositoryDetailContentTest {
     val composeRule = createComposeRule()
 
     @Test
-    fun default() {
+    fun default() = runTest {
+        ShadowLog.stream = System.out
         composeRule.setContent {
+            val engine = FakeImageLoaderEngine.Builder()
+                .intercept(
+                    "https://avatars.githubusercontent.com/u/7608725?v=4",
+                    FakeImage(100, 100, 100, true, Color.RED),
+                )
+                .default(ColorDrawable(Color.RED))
+                .build()
+            val imageLoader = ImageLoader.Builder(LocalPlatformContext.current)
+                .components { add(engine) }
+                .build()
+            SingletonImageLoader.setUnsafe(imageLoader)
             AppTheme {
                 RepositoryDetailContent(
                     info = RepositoryInfo(
                         name = "default/some",
                         owner = RepositoryOwner(
-                            ownerIconUrl = "",
+                            ownerIconUrl = "https://avatars.githubusercontent.com/u/7608725?v=4",
                         ),
                         language = "kotlin",
                         stargazersCount = 10,
@@ -36,10 +60,11 @@ class RepositoryDetailContentTest {
                         openIssuesCount = 1111,
                     ),
                     lastSearchDate = "検索日: 2024年1月1日 01:02:03",
+                    modifier = Modifier.background(androidx.compose.ui.graphics.Color.White),
                 )
             }
         }
-        composeRule.onNodeWithText("default")
+        composeRule.onNodeWithText(text = "default", substring = true)
             .assertExists()
         composeRule.onRoot().captureRoboImage()
     }

--- a/kmpShare/src/androidUnitTest/kotlin/jp/co/yumemi/codecheck/ui/search/SearchContentTest.kt
+++ b/kmpShare/src/androidUnitTest/kotlin/jp/co/yumemi/codecheck/ui/search/SearchContentTest.kt
@@ -1,0 +1,88 @@
+package jp.co.yumemi.codecheck.ui.search
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.text2.input.rememberTextFieldState
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performTextInput
+import com.github.takahirom.roborazzi.captureRoboImage
+import jp.co.yumemi.codecheck.api.RepositoryInfo
+import jp.co.yumemi.codecheck.api.RepositoryOwner
+import jp.co.yumemi.codecheck.ui.theme.AppTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.GraphicsMode
+
+@ExperimentalFoundationApi
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class SearchContentTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun defaultState_has_empty_text() {
+        composeRule.setContent {
+            AppTheme {
+                SearchContent(
+                    list = listOf(),
+                    textState = rememberTextFieldState(""),
+                    isLoading = false,
+                    onTriggerSearch = {},
+                    onNavigate = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(text = "empty")
+            .assertExists()
+        composeRule.onNodeWithContentDescription("clear")
+            .assertDoesNotExist()
+        composeRule.onRoot().captureRoboImage()
+    }
+
+    @Test
+    fun inputText_then_clear_button_exist() {
+        composeRule.setContent {
+            AppTheme {
+                SearchContent(
+                    list = listOf(
+                        RepositoryInfo(
+                            name = "aaa",
+                            owner = RepositoryOwner(""),
+                            language = null,
+                            stargazersCount = 1,
+                            watchersCount = 2,
+                            forksCount = 3,
+                            openIssuesCount = 4,
+                        ),
+                        RepositoryInfo(
+                            name = "bbb",
+                            owner = RepositoryOwner(""),
+                            language = null,
+                            stargazersCount = 1,
+                            watchersCount = 2,
+                            forksCount = 3,
+                            openIssuesCount = 4,
+                        ),
+                    ),
+                    textState = rememberTextFieldState(""),
+                    isLoading = false,
+                    onTriggerSearch = {},
+                    onNavigate = {},
+                )
+            }
+        }
+        composeRule.onNodeWithContentDescription("clear")
+            .assertDoesNotExist()
+        composeRule.onNodeWithTag("edit")
+            .performTextInput("abc")
+        composeRule.onNodeWithContentDescription("clear")
+            .assertExists()
+        composeRule.onRoot().captureRoboImage()
+    }
+}

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/components/SearchTextField.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/components/SearchTextField.kt
@@ -94,7 +94,7 @@ fun SearchTextField(
                     ) {
                         Icon(
                             imageVector = Icons.Default.Clear,
-                            contentDescription = "delete",
+                            contentDescription = "clear",
                             tint = MaterialTheme.colorScheme.onBackground,
                         )
                     }

--- a/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/detail/RepositoryDetailContent.kt
+++ b/kmpShare/src/commonMain/kotlin/jp/co/yumemi/codecheck/ui/detail/RepositoryDetailContent.kt
@@ -12,7 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
+import coil3.SingletonImageLoader
 import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
@@ -43,7 +43,7 @@ fun RepositoryDetailContent(
                 .data(info.owner.ownerIconUrl)
                 .build(),
             contentDescription = info.name,
-            imageLoader = ImageLoader(LocalPlatformContext.current),
+            imageLoader = SingletonImageLoader.get(LocalPlatformContext.current),
         )
         Text(text = info.name)
         Row(


### PR DESCRIPTION
# 関連Issue

- close #114 
- #66 

# 概要

- Roborazziのキャプチャをデフォルトで行うようにした(多分これでキャプチャの比較が正しく行われるようになるはず)
- 検索画面、詳細画面のキャプチャを取るテストを追加した（テスト自体は簡単なもの）
- Previewを追加（ただしcomposeResourcesを参照しているためPreviewが表示されない→参考: #110 ）