### PR TITLE
cleanup actionsが失敗していたのを修正

### DIFF
--- a/.github/workflows/pull_request_cleanup.yml
+++ b/.github/workflows/pull_request_cleanup.yml
@@ -7,9 +7,11 @@ on:
 jobs:
   delete-compare-branch:
     runs-on: ubuntu-latest
-    if:
     name: "cleanup compare diff branch"
     steps:
+      - uses: actions/checkout@v4
+
       - name: Cleanup outdated companion branches
+        shell: bash
         run: |
           git push origin --delete "companion_${{ github.head_ref }}"


### PR DESCRIPTION
fatal: not a git repository (or any of the parent directories): .git
.gitディレクトリないぞってことで、gitコマンド打つ前にcheckoutが必要だったっぽい