### PR TITLE
renovateでリリースノートへのリンクを追加するようにした

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,18 @@
       ],
       "groupName": "patch version up",
       "automerge": true
+    },
+    {
+      "matchPackagePatterns": [
+        "androidx"
+      ],
+      "changelogUrl": "https://developer.android.com/jetpack/androidx/versions/all-channel"
+    },
+    {
+      "matchPackagePrefixes": [
+        "androidx.test"
+      ],
+      "changelogUrl": "https://developer.android.com/jetpack/androidx/releases/test"
     }
   ]
 }


### PR DESCRIPTION
renovateでリリースノートについて調べてみた
（詳しくは下記コメント参照）

- #135 

下に書いてあるものが最終的に有効になる（上書きマッチになる）
androidx.testはtestのURLに、androidxのパッケージはall-channelのページへのリンクを埋め込む設定（にしたつもり、正しく動くかは適用してみないとわからん）